### PR TITLE
Hardcoded secret in the JWTAuthHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pem
+server

--- a/handlers/jwt.go
+++ b/handlers/jwt.go
@@ -6,10 +6,10 @@ import (
 	"github.com/dgrijalva/jwt-go"
 )
 
-func JWTAuthHandler(h http.HandlerFunc) http.HandlerFunc {
+func JWTAuthHandler(secret string, h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		token, err := jwt.ParseFromRequest(r, func(token *jwt.Token) (interface{}, error) {
-			return []byte("secret"), nil
+			return []byte(secret), nil
 		})
 		if err != nil || !token.Valid {
 			http.Error(w, "authorization failed", http.StatusUnauthorized)

--- a/hello/main.go
+++ b/hello/main.go
@@ -20,6 +20,7 @@ func main() {
 	var (
 		httpAddr   = flag.String("http", "0.0.0.0:80", "HTTP service address.")
 		healthAddr = flag.String("health", "0.0.0.0:81", "Health service address.")
+		secret     = flag.String("secret", "secret", "JWT signing secret.")
 	)
 	flag.Parse()
 
@@ -44,7 +45,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handlers.HelloHandler)
-	mux.Handle("/secure", handlers.JWTAuthHandler(handlers.HelloHandler))
+	mux.Handle("/secure", handlers.JWTAuthHandler(*secret, handlers.HelloHandler))
 	mux.Handle("/version", handlers.VersionHandler(version))
 
 	httpServer := manners.NewServer()

--- a/monolith/main.go
+++ b/monolith/main.go
@@ -47,7 +47,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handlers.HelloHandler)
 	mux.Handle("/login", handlers.LoginHandler(*secret, user.DB))
-	mux.Handle("/secure", handlers.JWTAuthHandler(handlers.HelloHandler))
+	mux.Handle("/secure", handlers.JWTAuthHandler(*secret, handlers.HelloHandler))
 	mux.Handle("/version", handlers.VersionHandler(version))
 
 	httpServer := manners.NewServer()


### PR DESCRIPTION
I thought it makes more sense to share a common secret between the Auth Service and the Hello Service with the --secret flag. Before the secret was hardcoded in the JWTAuthHandler, meaning that any other secret than "secret" in the Auth Service would result in an "Authorization failed" message.