### PR TITLE
fix typo for bcrypt hash

### DIFF
--- a/user/users.go
+++ b/user/users.go
@@ -11,7 +11,7 @@ type Users map[string]User
 var DB = Users{
 	"user": User{
 		Username: "user",
-		// bcrypt has for "password"
+		// bcrypt hash for "password"
 		PasswordHash: "$2a$10$KgFhp4HAaBCRAYbFp5XYUOKrbO90yrpUQte4eyafk4Tu6mnZcNWiK",
 		Email:        "user@example.com",
 	},


### PR DESCRIPTION
Fix a typo in the comment for bcrypt hash.